### PR TITLE
Typo fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Things to check
 
 - For any logging statements, is there any chance that they could be logging sensitive data?
-- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
+- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.
 
 ## Security considerations
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You can leverage [cloud.gov’s identity hub](https://cloud.gov/docs/services/cloud-gov-identity-provider/) to reduce the burden of authenticating users from government agencies and partners in your app.
 
 This demo has two parts: 
-  1. [running an application in cloud.gov that uses the identiy provider](#1-run-an-application-in-cloudgov-that-uses-the-identity-provider)
+  1. [running an application in cloud.gov that uses the identity provider](#1-run-an-application-in-cloudgov-that-uses-the-identity-provider)
   2. [running a local UAA server for local development](#2-run-a-local-uaa-server-for-local-development)
 
 ## 1. Run an application in cloud.gov that uses the identity provider


### PR DESCRIPTION
e## Changes proposed in this pull request:

- Typo fixes

## Things to check

- [x] For any logging statements, is there any chance that they could be logging sensitive data?
- [x] Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

No change in security posture; typo fixes in existing public-facing files
